### PR TITLE
Persistent files

### DIFF
--- a/image/meta-gcp-iot/recipes-core/netbase/netbase_%.bbappend
+++ b/image/meta-gcp-iot/recipes-core/netbase/netbase_%.bbappend
@@ -1,0 +1,8 @@
+inherit deploy
+
+do_deploy() {
+   install -d ${DEPLOYDIR}/persist
+   mv ${D}${sysconfdir}/hosts ${DEPLOYDIR}/persist
+   ln -s /data/hosts ${D}${sysconfdir}/hosts
+}
+addtask do_deploy after do_install before do_package

--- a/image/meta-gcp-iot/recipes-gcp/images/gcp-mender-demo-image.bb
+++ b/image/meta-gcp-iot/recipes-gcp/images/gcp-mender-demo-image.bb
@@ -31,3 +31,5 @@ IMAGE_INSTALL_append = " \
 
 inherit extrausers
 EXTRA_USERS_PARAMS = "usermod -P mender_gcp_ota root;"
+
+MENDER_DATA_PART_DIR = "${DEPLOY_DIR_IMAGE}/persist"

--- a/image/meta-gcp-iot/recipes-mender/mender/mender-gcp-iot.inc
+++ b/image/meta-gcp-iot/recipes-mender/mender/mender-gcp-iot.inc
@@ -37,3 +37,12 @@ do_compile_prepend() {
 }
 
 RDEPENDS_${PN} += " bash openssl"
+
+inherit deploy
+
+do_deploy() {
+   install -d ${DEPLOYDIR}/persist/mender
+   mv ${D}${sysconfdir}/mender/mender.conf ${DEPLOYDIR}/persist/mender
+   ln -s /data/mender/mender.conf ${D}${sysconfdir}/mender/mender.conf
+}
+addtask do_deploy after do_install before do_package


### PR DESCRIPTION
This PR sets up /etc/hosts and /etc/mender/mender.conf as symlinks into /data.  This allows any changes to these files to persist across updates and not require explicit changes to be reapplied.